### PR TITLE
Add Inno Setup install action

### DIFF
--- a/install-innosetup/action.yml
+++ b/install-innosetup/action.yml
@@ -1,0 +1,26 @@
+name: "Install Inno Setup"
+
+description: "Install Inno Setup"
+
+inputs:
+  version:
+    description: "Version"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          innosetup-${{ inputs.version }}
+        key: ${{ runner.os }}-innosetup-${{ inputs.version }}
+
+    - name: Install
+      shell: pwsh
+      run: |
+        Invoke-WebRequest -Uri https://files.jrsoftware.org/is/6/innosetup-${{ inputs.version }}.exe -OutFile innosetup-${{ inputs.version }}.exe
+        Start-Process -FilePath ".\innosetup-${{ inputs.version }}.exe" -ArgumentList "/VERYSILENT", "/CURRENTUSER", "/DIR=innosetup-${{ inputs.version }}" -Wait
+        Remove-Item .\innosetup-${{ inputs.version }}.exe
+        Add-Content $env:GITHUB_PATH "$(Get-Location)\innosetup-${{ inputs.version }}"


### PR DESCRIPTION
With these 2 commits, CMake now downloads Inno Setup directly, instead of the unofficial Nuget package:
https://github.com/surge-synthesizer/surge/commit/36a2d4c3b001a01502eebeab9f66db9de17a902e
https://github.com/surge-synthesizer/shortcircuit-xt/commit/60ef18c8c20c8a99dee92a27eed5662ca50b7f93

This action will allow us to install & cache Inno Setup in the workflows, and the new CMake find_program should pick it up and skip the download.