### PR TITLE
Add: Install Ninja action

### DIFF
--- a/install-ninja/action.yml
+++ b/install-ninja/action.yml
@@ -1,0 +1,38 @@
+name: "Ninja"
+
+description: "Install Ninja"
+
+inputs:
+  version:
+    description: "Version"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Ninja
+      id: cache-ninja
+      uses: actions/cache@v4
+      with:
+        path: |
+          ninja
+        key: ${{ runner.os }}-ninja-${{ inputs.version }}
+
+    - name: Install Ninja
+      if: steps.cache-ninja.outputs.cache-hit != 'true'
+      shell: pwsh
+      run: |
+        switch ("${{ runner.os }}") {
+          "Windows" { $platform = "win" }
+          "Linux" { $platform = "linux" }
+          "macOS" { $platform = "mac" }
+          default { throw "Unsupported OS: ${{runner.os}}" }
+        }
+        gh release download v${{ inputs.version }} -p "*$platform.zip" -R ninja-build/ninja
+        Expand-Archive .\ninja-$platform.zip -DestinationPath ninja
+        Remove-Item .\ninja-$platform.zip
+
+    - name: Add Ninja to path
+      shell: pwsh
+      run: |
+        Add-Content $env:GITHUB_PATH "$(Get-Location)\ninja"

--- a/prepare-for-juce/action.yml
+++ b/prepare-for-juce/action.yml
@@ -16,7 +16,9 @@ runs:
       run: echo "MacOS is just fine"
 
     - name: Install Ninja
-      uses: seanmiddleditch/gha-setup-ninja@master
+      uses: surge-synthesizer/sst-githubactions/install-ninja@main
+      with:
+        version: "1.13.1"
 
     - name: Install Linux Deps; pick GCC
       if: inputs.os == 'Linux'


### PR DESCRIPTION
Our current Ninja install action has been archived, as of May 13, 2025 https://github.com/seanmiddleditch/gha-setup-ninja

I think all the runners have ninja, but it's nice to have a version pinned, so here's a replacement action.